### PR TITLE
Change slack link to point to auto-invite link so people can directly join HackMGM slack without having to manually ask someone to add them

### DIFF
--- a/about.html
+++ b/about.html
@@ -63,7 +63,7 @@
               <li><a href="https://www.meetup.com/hackMGM/" target="_blank"><i class="fa fa-meetup fa-2x"></i></a></li>
               <li><a href="https://twitter.com/hackmgm" target="_blank"><i class="fa fa-twitter fa-2x"></i></a></li>
               <li><a href="https://www.facebook.com/groups/hackMGM/" target="_blank"><i class="fa fa-facebook fa-2x"></i></a></li>
-              <li><a href="https://hackmgm.slack.com/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
+              <li><a href="https://hackmgm.signup.team/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
 
             </ul>
           </div><!--/.nav-collapse -->

--- a/getinvolved.html
+++ b/getinvolved.html
@@ -63,7 +63,7 @@
               <li><a href="https://www.meetup.com/hackMGM/" target="_blank"><i class="fa fa-meetup fa-2x"></i></a></li>
               <li><a href="https://twitter.com/hackmgm" target="_blank"><i class="fa fa-twitter fa-2x"></i></a></li>
               <li><a href="https://www.facebook.com/groups/hackMGM/" target="_blank"><i class="fa fa-facebook fa-2x"></i></a></li>
-              <li><a href="https://hackmgm.slack.com/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
+              <li><a href="https://hackmgm.signup.team/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
 
             </ul>
           </div><!--/.nav-collapse -->

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
               <li><a href="https://www.meetup.com/hackMGM/" target="_blank"><i class="fa fa-meetup fa-2x"></i></a></li>
               <li><a href="https://twitter.com/hackmgm" target="_blank"><i class="fa fa-twitter fa-2x"></i></a></li>
               <li><a href="https://www.facebook.com/groups/hackMGM/" target="_blank"><i class="fa fa-facebook fa-2x"></i></a></li>
-              <li><a href="https://hackmgm.slack.com/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
+              <li><a href="https://hackmgm.signup.team/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
 
             </ul>
           </div><!--/.nav-collapse -->

--- a/submit_idea.html
+++ b/submit_idea.html
@@ -50,7 +50,7 @@
               <li><a href="https://www.meetup.com/hackMGM/" target="_blank"><i class="fa fa-meetup fa-2x"></i></a></li>
               <li><a href="https://twitter.com/hackmgm" target="_blank"><i class="fa fa-twitter fa-2x"></i></a></li>
               <li><a href="https://www.facebook.com/groups/hackMGM/" target="_blank"><i class="fa fa-facebook fa-2x"></i></a></li>
-              <li><a href="https://hackmgm.slack.com/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
+              <li><a href="https://hackmgm.signup.team/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
             </ul>
           </div><!--/.nav-collapse -->
         </div><!--/.container-fluid -->

--- a/submit_idea.php
+++ b/submit_idea.php
@@ -103,7 +103,7 @@ if ($errEmail || $errName || $errIdea || !$mail_sent)
               <li><a href="https://www.meetup.com/hackMGM/" target="_blank"><i class="fa fa-meetup fa-2x"></i></a></li>
               <li><a href="https://twitter.com/hackmgm" target="_blank"><i class="fa fa-twitter fa-2x"></i></a></li>
               <li><a href="https://www.facebook.com/groups/hackMGM/" target="_blank"><i class="fa fa-facebook fa-2x"></i></a></li>
-              <li><a href="https://hackmgm.slack.com/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
+              <li><a href="https://hackmgm.signup.team/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
             </ul>
           </div><!--/.nav-collapse -->
         </div><!--/.container-fluid -->

--- a/template.html
+++ b/template.html
@@ -63,7 +63,7 @@
               <li><a href="https://www.meetup.com/hackMGM/" target="_blank"><i class="fa fa-meetup fa-2x"></i></a></li>
               <li><a href="https://twitter.com/hackmgm" target="_blank"><i class="fa fa-twitter fa-2x"></i></a></li>
               <li><a href="https://www.facebook.com/groups/hackMGM/" target="_blank"><i class="fa fa-facebook fa-2x"></i></a></li>
-              <li><a href="https://hackmgm.slack.com/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
+              <li><a href="https://hackmgm.signup.team/" target="_blank"><i class="fa fa-slack fa-2x"></i></a></li>
 
             </ul>
           </div><!--/.nav-collapse -->


### PR DESCRIPTION
Note: The Slack auto-invite link is from https://www.meetup.com/hackMGM/messages/boards/thread/50553054