### PR TITLE
fix(submit_idea): fix notices in submit_idea.php script

### DIFF
--- a/submit_idea.php
+++ b/submit_idea.php
@@ -3,7 +3,8 @@ $submitteremail = $_POST['personemail'];
 $submittername = $_POST['personname'];
 $submitteridea = $_POST['ideabox'];
 $submitterabout = $_POST['aboutcontact'];
-$honeypot = $_POST['foo'];
+
+$mail_sent = false;
 
 /* Required fields */
 if (!isset($_POST['personemail']) || !filter_var($_POST['personemail'], FILTER_VALIDATE_EMAIL)) {


### PR DESCRIPTION
This fixes #29 in which a notice is generated if the form is submitted empty. Removes assignment of
unused variable $honeypot and initializes $email_sent as false

https://github.com/HackMGM/hackmgm.org/issues/29